### PR TITLE
Automatically strip symbols from binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 termsize = "0.1"
 tokio = { version = "1", features = ["full"] }
+
+[profile.release]
+strip = true


### PR DESCRIPTION
I am maintaining an AUR package for this repository and this significantly reduces binary sizes for Linux builds.